### PR TITLE
Update 6.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ numbers don't!
 
 ## Key differences
 
-* `choo/html` removed - use [bel](https://wzrd.in/standalone/bel@latest) (`npm install bel`) directly
+* `choo/html` removed - use [nanohtml](https://wzrd.in/standalone/nanohtml@latest) (`npm install nanohtml`) directly
 * Removed router:
   * `choo()` no longer takes an `opts` argument
   * `choo.route(location, handler)` replaced by `choo.view(handler)`
@@ -51,7 +51,7 @@ routing-related things, use `choo.view` over `choo.route`, and you'll be fine.
 
 ## Example
 ```js
-var html = require('bel')
+var html = require('nanohtml')
 var choo = require('nanochoo')
 
 var app = choo()

--- a/example/index.js
+++ b/example/index.js
@@ -9,5 +9,4 @@ app.use(require('choo-devtools'))
 app.use(require('./store'))
 app.view(require('./view'))
 
-if (module.parent) module.exports = app
-else app.mount('body')
+module.exports = app.mount('body')

--- a/example/view.js
+++ b/example/view.js
@@ -1,4 +1,4 @@
-var html = require('bel')
+var html = require('nanohtml')
 
 module.exports = mainView
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -25,6 +25,7 @@ function Choo () {
   // properties for internal use only
   this._hasWindow = typeof window !== 'undefined'
   this._loaded = false
+  this._stores = []
   this._tree = null
   this._viewHandler = null
 
@@ -58,7 +59,10 @@ Choo.prototype.view = function (handler) {
 
 Choo.prototype.use = function (cb) {
   assert.equal(typeof cb, 'function', 'choo.use: cb should be type function')
-  cb(this.state, this.emitter, this)
+  var self = this
+  this._stores.push(function () {
+    cb(self.state, self.emitter, self)
+  })
 }
 
 Choo.prototype.start = function () {
@@ -66,6 +70,10 @@ Choo.prototype.start = function () {
   assert.equal(typeof this._viewHandler, 'function', 'choo.start: view handler was not found. try calling choo.view')
 
   var self = this
+
+  this._stores.forEach(function (initStore) {
+    initStore()
+  })
 
   function render () {
     return self._viewHandler(self.state, function (eventName, data) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,7 +14,7 @@ Choo.prototype.toString = function (state) {
     self.emitter.emit.apply(self.emitter, arguments)
   })
   assert.ok(html, 'choo.toString: no valid value returned for the view')
-  return html.toString()
+  return typeof html.outerHTML === 'string' ? html.outerHTML : html.toString()
 }
 
 module.exports = Choo

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,6 +10,10 @@ Choo.prototype.toString = function (state) {
 
   var self = this
 
+  this._stores.forEach(function (initStore) {
+    initStore()
+  })
+
   var html = self._viewHandler(self.state, function (eventName, data) {
     self.emitter.emit.apply(self.emitter, arguments)
   })

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,6 +18,7 @@ Choo.prototype.toString = function (state) {
     self.emitter.emit.apply(self.emitter, arguments)
   })
   assert.ok(html, 'choo.toString: no valid value returned for the view')
+  assert(!Array.isArray(html), 'choo.toString: return value was an array for the view')
   return typeof html.outerHTML === 'string' ? html.outerHTML : html.toString()
 }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.8.0",
     "discify": "^1.6.0",
+    "hyperscript": "^2.0.2",
     "pretty-bytes-cli": "^2.0.0",
     "spok": "^0.8.1",
     "standard": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.20",
-    "bel": "^5.1.5",
     "browserify": "^14.3.0",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.8.0",
     "discify": "^1.6.0",
     "hyperscript": "^2.0.2",
+    "nanohtml": "^1.2.4",
     "pretty-bytes-cli": "^2.0.0",
     "spok": "^0.8.1",
     "standard": "^10.0.0",

--- a/test.js
+++ b/test.js
@@ -1,10 +1,11 @@
 var tape = require('tape')
+var h = require('hyperscript')
 
 var html = require('bel')
 var raw = require('bel/raw')
 var choo = require('./')
 
-tape('should render on the server', function (t) {
+tape('should render on the server with bel', function (t) {
   var app = choo()
   app.view(function (state, emit) {
     var strong = '<strong>Hello filthy planet</strong>'
@@ -13,6 +14,17 @@ tape('should render on the server', function (t) {
     `
   })
   var res = app.toString()
+  var exp = '<p><strong>Hello filthy planet</strong></p>'
+  t.equal(res.toString().trim(), exp, 'result was OK')
+  t.end()
+})
+
+tape('should render on the server with hyperscript', function (t) {
+  var app = choo()
+  app.route('/', function (state, emit) {
+    return h('p', h('strong', 'Hello filthy planet'))
+  })
+  var res = app.toString('/')
   var exp = '<p><strong>Hello filthy planet</strong></p>'
   t.equal(res.toString().trim(), exp, 'result was OK')
   t.end()

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
 var tape = require('tape')
 var h = require('hyperscript')
 
-var html = require('bel')
-var raw = require('bel/raw')
+var html = require('nanohtml')
+var raw = require('nanohtml/raw')
 var choo = require('./')
 
-tape('should render on the server with bel', function (t) {
+tape('should render on the server with nanohtml', function (t) {
   var app = choo()
   app.view(function (state, emit) {
     var strong = '<strong>Hello filthy planet</strong>'


### PR DESCRIPTION
Update to choo 6.13

:wave: This patch cherry-picks most of the non-router commits between 6.8 and 6.13.

I didn't include the component cache here yet because that is quite big (1kb or so) and not always essential. I think we could still include it but make it optional with a decorator like:

```js
const choo = require('nanochoo')
const useComponents = require('nanochoo/component')
const app = useComponents(choo())
```

or it might work as a store too since it exposes itself on `state.cache` anyway.

whadya think?
