### PR TITLE
Exclude example node_modules from npm package.

### DIFF
--- a/example/.npmignore
+++ b/example/.npmignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Saves some 100+MB

http://packagephobia.now.sh/result?p=nanochoo